### PR TITLE
Show news items using AdapterList

### DIFF
--- a/app/src/main/java/com/github/zsoltk/pokedex/entity/NewsItem.kt
+++ b/app/src/main/java/com/github/zsoltk/pokedex/entity/NewsItem.kt
@@ -1,6 +1,7 @@
 package com.github.zsoltk.pokedex.entity
 
 data class NewsItem(
+    val indexInList: Int,
     val title: String = "Pokémon Rumble Rush Arrives Soon",
     val date: String = "15 May 2019"
 )

--- a/app/src/main/java/com/github/zsoltk/pokedex/entity/NewsItem.kt
+++ b/app/src/main/java/com/github/zsoltk/pokedex/entity/NewsItem.kt
@@ -1,7 +1,6 @@
 package com.github.zsoltk.pokedex.entity
 
 data class NewsItem(
-    val indexInList: Int,
     val title: String = "Pokémon Rumble Rush Arrives Soon",
     val date: String = "15 May 2019"
 )

--- a/app/src/main/java/com/github/zsoltk/pokedex/home/Home.kt
+++ b/app/src/main/java/com/github/zsoltk/pokedex/home/Home.kt
@@ -27,18 +27,31 @@ interface Home {
     }
 
     companion object {
+        object Header
+
         @Composable
         fun Content(onMenuItemSelected: (MenuItem) -> Unit) {
-            AdapterList(data = List(1000) { NewsItem(it) }) {
-                if(it.indexInList == 0) {
-                    MainAppBar(onMenuItemSelected)
-                    Container(modifier = LayoutPadding(32.dp)) {
-                        NewsHeaderSection()
-                    }
+            val items = listOf(Header) + List(1000) { NewsItem() }
+            AdapterList(items) {
+                when (it) {
+                    is Header -> ListHeader(onMenuItemSelected)
+                    is NewsItem -> ListItem(it)
                 }
-                Container(modifier = LayoutPadding(left = 32.dp, right = 32.dp)) {
-                    NewsCard(newsItem = it)
-                }
+            }
+        }
+
+        @Composable
+        fun ListHeader(onMenuItemSelected: (MenuItem) -> Unit) {
+            MainAppBar(onMenuItemSelected)
+            Container(modifier = LayoutPadding(32.dp)) {
+                NewsHeaderSection()
+            }
+        }
+
+        @Composable
+        fun ListItem(item: NewsItem) {
+            Container(modifier = LayoutPadding(left = 32.dp, right = 32.dp)) {
+                NewsCard(newsItem = item)
             }
         }
     }

--- a/app/src/main/java/com/github/zsoltk/pokedex/home/Home.kt
+++ b/app/src/main/java/com/github/zsoltk/pokedex/home/Home.kt
@@ -1,15 +1,16 @@
 package com.github.zsoltk.pokedex.home
 
 import androidx.compose.Composable
-import androidx.ui.foundation.VerticalScroller
-import androidx.ui.layout.Column
+import androidx.ui.foundation.AdapterList
 import androidx.ui.layout.Container
 import androidx.ui.layout.LayoutPadding
 import androidx.ui.tooling.preview.Preview
 import androidx.ui.unit.dp
 import com.github.zsoltk.pokedex.R
+import com.github.zsoltk.pokedex.entity.NewsItem
 import com.github.zsoltk.pokedex.home.appbar.MainAppBar
-import com.github.zsoltk.pokedex.home.news.NewsSection
+import com.github.zsoltk.pokedex.home.news.NewsCard
+import com.github.zsoltk.pokedex.home.news.NewsHeaderSection
 
 interface Home {
 
@@ -28,12 +29,15 @@ interface Home {
     companion object {
         @Composable
         fun Content(onMenuItemSelected: (MenuItem) -> Unit) {
-            VerticalScroller {
-                Column {
+            AdapterList(data = List(1000) { NewsItem(it) }) {
+                if(it.indexInList == 0) {
                     MainAppBar(onMenuItemSelected)
                     Container(modifier = LayoutPadding(32.dp)) {
-                        NewsSection()
+                        NewsHeaderSection()
                     }
+                }
+                Container(modifier = LayoutPadding(left = 32.dp, right = 32.dp)) {
+                    NewsCard(newsItem = it)
                 }
             }
         }

--- a/app/src/main/java/com/github/zsoltk/pokedex/home/news/NewsSection.kt
+++ b/app/src/main/java/com/github/zsoltk/pokedex/home/news/NewsSection.kt
@@ -2,33 +2,17 @@ package com.github.zsoltk.pokedex.home.news
 
 import androidx.compose.Composable
 import androidx.ui.core.Text
-import androidx.ui.layout.Column
 import androidx.ui.layout.Container
 import androidx.ui.layout.LayoutGravity
-import androidx.ui.layout.LayoutHeight
 import androidx.ui.layout.LayoutWidth
-import androidx.ui.layout.Spacer
 import androidx.ui.layout.Stack
 import androidx.ui.material.MaterialTheme
 import androidx.ui.res.colorResource
 import androidx.ui.text.font.FontWeight
 import androidx.ui.tooling.preview.Preview
-import androidx.ui.unit.dp
 import com.github.zsoltk.pokedex.R
-import com.github.zsoltk.pokedex.entity.NewsItem
 
 @Preview
-@Composable
-fun NewsSection() {
-    Container(expanded = true) {
-        Column {
-            NewsHeaderSection()
-            Spacer(modifier = LayoutHeight(32.dp))
-            NewsList()
-        }
-    }
-}
-
 @Composable
 fun NewsHeaderSection() {
     Stack(modifier = LayoutWidth.Fill) {
@@ -60,21 +44,4 @@ fun NewsViewAll() {
             color = colorResource(R.color.poke_blue)
         )
     )
-}
-
-@Composable
-fun NewsList() {
-    val news = listOf(
-        NewsItem(),
-        NewsItem(),
-        NewsItem(),
-        NewsItem(),
-        NewsItem(),
-        NewsItem(),
-        NewsItem()
-    )
-
-    news.forEach {
-        NewsCard(it)
-    }
 }


### PR DESCRIPTION
The `dev-05` release of Compose comes with `AdapterList`, a way to only render what's visible on screen. I've tried to implement `ListAdapter` for Pokedex.

I'm not so happy with the result, so this PR is mostly a place for discussion. The question I'd like to answer: Is there a way to keep the `AdapterList` contained within `NewsSection.kt`? 

My first naive solution was to just change the contents of `NewsList()` to render an `AdapterList`. However, this didn't show any news cards anymore. I tried a lot of different configurations, but any time I tried to put the `AdapterList` inside another scrollable composable, it broke.